### PR TITLE
feat: add preferable country guesser

### DIFF
--- a/src/components/VPhoneInput.vue
+++ b/src/components/VPhoneInput.vue
@@ -193,6 +193,7 @@ import { VPhoneCountriesItems, VPhoneInputRules } from '@/types/components';
 import { Country, CountryGuesser, CountryIso2 } from '@/types/countries';
 import { CountryIconMode, Message, MessageOptions, MessageResolver } from '@/types/options';
 import { PhoneNumberFormat, PhoneNumberObject } from '@/types/phone';
+import isPreferableCountryGuesser from '@/utils/countries/isPreferableCountryGuesser';
 import normalizeCountryIso2 from '@/utils/countries/normalizeCountryIso2';
 import mapWithKey from '@/utils/mapKeys';
 import { getOption } from '@/utils/options';
@@ -616,6 +617,10 @@ export default Vue.extend({
       if (this.lazyCountry) {
         this.guessingCountry = false;
         this.$emit('update:country', this.lazyCountry);
+
+        if (isPreferableCountryGuesser(this.countryGuesser)) {
+          this.countryGuesser.setPreference(this.lazyCountry);
+        }
       } else {
         this.$nextTick(() => {
           if (!this.lazyCountry) {

--- a/src/types/countries.ts
+++ b/src/types/countries.ts
@@ -9,3 +9,7 @@ export interface Country {
 export interface CountryGuesser {
   guess: () => Promise<CountryIso2 | undefined>;
 }
+
+export interface PreferableCountryGuesser extends CountryGuesser {
+  setPreference: (country: CountryIso2) => void;
+}

--- a/src/utils/countries/isPreferableCountryGuesser.ts
+++ b/src/utils/countries/isPreferableCountryGuesser.ts
@@ -1,0 +1,7 @@
+import { CountryGuesser, PreferableCountryGuesser } from '@/types/countries';
+
+export default function isPreferableCountryGuesser(
+  countryGuesser: CountryGuesser,
+): countryGuesser is PreferableCountryGuesser {
+  return 'setPreference' in countryGuesser;
+}

--- a/src/utils/countries/memoIp2cCountryGuesser.ts
+++ b/src/utils/countries/memoIp2cCountryGuesser.ts
@@ -1,7 +1,9 @@
-import { CountryIso2 } from '@/types/countries';
+import { CountryIso2, PreferableCountryGuesser } from '@/types/countries';
 import Ip2cCountryGuesser from '@/utils/countries/ip2cCountryGuesser';
 
-export default class MemoIp2cCountryGuesser extends Ip2cCountryGuesser {
+export default class MemoIp2cCountryGuesser
+  extends Ip2cCountryGuesser
+  implements PreferableCountryGuesser {
   private memoCountry = undefined as CountryIso2 | undefined;
 
   public async guess(): Promise<CountryIso2 | undefined> {
@@ -10,5 +12,9 @@ export default class MemoIp2cCountryGuesser extends Ip2cCountryGuesser {
     }
 
     return this.memoCountry;
+  }
+
+  public setPreference(country: CountryIso2): void {
+    this.memoCountry = country;
   }
 }

--- a/src/utils/countries/storageMemoIp2cCountryGuesser.ts
+++ b/src/utils/countries/storageMemoIp2cCountryGuesser.ts
@@ -1,4 +1,4 @@
-import { CountryIso2 } from '@/types/countries';
+import { CountryIso2, PreferableCountryGuesser } from '@/types/countries';
 import Ip2cCountryGuesser from '@/utils/countries/ip2cCountryGuesser';
 
 interface StorageMemoIp2cCountryGuesserOptions {
@@ -6,7 +6,9 @@ interface StorageMemoIp2cCountryGuesserOptions {
   key?: string;
 }
 
-export default class StorageMemoIp2cCountryGuesser extends Ip2cCountryGuesser {
+export default class StorageMemoIp2cCountryGuesser
+  extends Ip2cCountryGuesser
+  implements PreferableCountryGuesser {
   private readonly storage: Storage;
 
   private readonly key: string;
@@ -19,16 +21,28 @@ export default class StorageMemoIp2cCountryGuesser extends Ip2cCountryGuesser {
   }
 
   public async guess(): Promise<CountryIso2 | undefined> {
-    const storageCountry = this.storage.getItem(this.key);
+    const storageCountry = this.retrieveStoredCountry();
     if (storageCountry) {
       return storageCountry;
     }
 
     const country = await super.guess();
     if (country) {
-      this.storage.setItem(this.key, country);
+      this.saveStoredCountry(country);
     }
 
     return country;
+  }
+
+  public setPreference(country: CountryIso2): void {
+    this.saveStoredCountry(country);
+  }
+
+  private retrieveStoredCountry(): CountryIso2 | undefined {
+    return this.storage.getItem(this.key) || undefined;
+  }
+
+  private saveStoredCountry(country: CountryIso2): void {
+    this.storage.setItem(this.key, country);
   }
 }

--- a/tests/unit/VPhoneInput.spec.js
+++ b/tests/unit/VPhoneInput.spec.js
@@ -1,4 +1,4 @@
-import { VPhoneInput } from '@/entry.esm';
+import { Ip2cCountryGuesser, VPhoneInput } from '@/entry.esm';
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 
@@ -17,6 +17,10 @@ describe('VPhoneInput.vue', () => {
     localVue: createLocalVue(),
     vuetify: new Vuetify(),
     ...options,
+    propsData: {
+      countryGuesser: new Ip2cCountryGuesser(),
+      ...(options.propsData || {}),
+    },
   });
 
   it('should use all countries', () => {

--- a/tests/unit/VPhoneInput.spec.js
+++ b/tests/unit/VPhoneInput.spec.js
@@ -1,17 +1,12 @@
 import { Ip2cCountryGuesser, VPhoneInput } from '@/entry.esm';
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuetify from 'vuetify';
+import fakeIp2cFetch from './utils/fakeIp2cFetch';
 
 describe('VPhoneInput.vue', () => {
   const wait = (delay) => new Promise((r) => {
     setTimeout(r, delay);
   });
-
-  const mockFetch = () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
-  };
 
   const makeVPhoneInput = (options = {}) => mount(VPhoneInput, {
     localVue: createLocalVue(),
@@ -23,8 +18,11 @@ describe('VPhoneInput.vue', () => {
     },
   });
 
+  beforeAll(() => {
+    fakeIp2cFetch();
+  });
+
   it('should use all countries', () => {
-    mockFetch();
     const wrapper = makeVPhoneInput();
 
     expect(wrapper.vm.countriesItems.length).toEqual(250);
@@ -34,7 +32,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should filter countries using onlyCountries', () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({
       propsData: { onlyCountries: ['FR', 'be'] },
     });
@@ -46,7 +43,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should filter countries using ignoredCountries', () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({
       propsData: { ignoredCountries: ['FR', 'be'] },
     });
@@ -58,7 +54,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should use the only one country', async () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({
       propsData: { onlyCountries: ['AF'] },
     });
@@ -70,7 +65,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should prepend preferred countries with divider', () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({
       propsData: { preferredCountries: ['FR', 'be'] },
     });
@@ -82,7 +76,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should prepend preferred countries without divider', () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({
       propsData: { preferredCountries: ['FR', 'be'], onlyCountries: ['FR', 'BE'] },
     });
@@ -94,7 +87,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should only use custom rules', async () => {
-    mockFetch();
     let functionRuleParams;
     const wrapper = makeVPhoneInput({
       propsData: {
@@ -131,7 +123,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should use country prop for lazy country init', async () => {
-    mockFetch();
     const wrapper = makeVPhoneInput({ propsData: { country: 'AF' } });
 
     expect(wrapper.vm.lazyCountry).toEqual('AF');
@@ -142,7 +133,6 @@ describe('VPhoneInput.vue', () => {
   });
 
   it('should use country prop for lazy country update', async () => {
-    mockFetch();
     const wrapper = makeVPhoneInput();
 
     await wait(50);

--- a/tests/unit/ip2cCountryGuesser.spec.js
+++ b/tests/unit/ip2cCountryGuesser.spec.js
@@ -1,24 +1,21 @@
 import { Ip2cCountryGuesser } from '@/entry.esm';
+import fakeIp2cFetch from './utils/fakeIp2cFetch';
 
 describe('ip2cCountryGuesser.js', () => {
   it('should return undefined when fetch fails', async () => {
-    global.fetch = jest.fn(() => Promise.reject());
+    fakeIp2cFetch(Promise.reject());
 
     expect(await new Ip2cCountryGuesser().guess()).toBeUndefined();
   });
 
   it('should return undefined when fetch succeeded with invalid result', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('0'),
-    }));
+    fakeIp2cFetch(Promise.resolve('0'));
 
     expect(await new Ip2cCountryGuesser().guess()).toBeUndefined();
   });
 
   it('should return undefined when fetch succeeded with valid result', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
+    fakeIp2cFetch();
 
     expect(await new Ip2cCountryGuesser().guess()).toEqual('FR');
   });

--- a/tests/unit/isPreferableCountryGuesser.spec.js
+++ b/tests/unit/isPreferableCountryGuesser.spec.js
@@ -1,0 +1,14 @@
+import {
+  Ip2cCountryGuesser,
+  MemoIp2cCountryGuesser,
+  StorageMemoIp2cCountryGuesser,
+} from '@/entry.esm';
+import isPreferableCountryGuesser from '@/utils/countries/isPreferableCountryGuesser';
+
+describe('isPreferableCountryGuesser.js', () => {
+  it('should differentiate preferable from classic country guessers', () => {
+    expect(isPreferableCountryGuesser(new Ip2cCountryGuesser())).toBeFalsy();
+    expect(isPreferableCountryGuesser(new MemoIp2cCountryGuesser())).toBeTruthy();
+    expect(isPreferableCountryGuesser(new StorageMemoIp2cCountryGuesser())).toBeTruthy();
+  });
+});

--- a/tests/unit/memoIp2cCountryGuesser.spec.js
+++ b/tests/unit/memoIp2cCountryGuesser.spec.js
@@ -1,10 +1,9 @@
 import { MemoIp2cCountryGuesser } from '@/entry.esm';
+import fakeIp2cFetch from './utils/fakeIp2cFetch';
 
 describe('memoIp2cCountryGuesser.js', () => {
   it('should memoize promise from ip2c country guesser when not undefined', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('0'),
-    }));
+    fakeIp2cFetch(Promise.resolve('0'));
 
     const memoIp2cCountryGuesser = new MemoIp2cCountryGuesser();
 
@@ -14,9 +13,7 @@ describe('memoIp2cCountryGuesser.js', () => {
     expect(await memoIp2cCountryGuesser.guess()).toBeUndefined();
     expect(global.fetch.mock.calls.length).toBe(2);
 
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
+    fakeIp2cFetch();
 
     expect(await memoIp2cCountryGuesser.guess()).toBe('FR');
     expect(global.fetch.mock.calls.length).toBe(1);
@@ -26,9 +23,7 @@ describe('memoIp2cCountryGuesser.js', () => {
   });
 
   it('should use default storage and key', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
+    fakeIp2cFetch();
 
     const memoIp2cCountryGuesser = new MemoIp2cCountryGuesser();
 

--- a/tests/unit/memoIp2cCountryGuesser.spec.js
+++ b/tests/unit/memoIp2cCountryGuesser.spec.js
@@ -24,4 +24,24 @@ describe('memoIp2cCountryGuesser.js', () => {
     expect(await memoIp2cCountryGuesser.guess()).toBe('FR');
     expect(global.fetch.mock.calls.length).toBe(1);
   });
+
+  it('should use default storage and key', async () => {
+    global.fetch = jest.fn(() => Promise.resolve({
+      text: () => Promise.resolve('1;FR'),
+    }));
+
+    const memoIp2cCountryGuesser = new MemoIp2cCountryGuesser();
+
+    expect(await memoIp2cCountryGuesser.guess()).toBe('FR');
+    expect(global.fetch.mock.calls.length).toBe(1);
+    expect(await memoIp2cCountryGuesser.guess()).toBe('FR');
+    expect(global.fetch.mock.calls.length).toBe(1);
+
+    memoIp2cCountryGuesser.setPreference('AF');
+
+    expect(await memoIp2cCountryGuesser.guess()).toBe('AF');
+    expect(global.fetch.mock.calls.length).toBe(1);
+    expect(await memoIp2cCountryGuesser.guess()).toBe('AF');
+    expect(global.fetch.mock.calls.length).toBe(1);
+  });
 });

--- a/tests/unit/storageMemoIp2cCountryGuesser.spec.js
+++ b/tests/unit/storageMemoIp2cCountryGuesser.spec.js
@@ -1,4 +1,5 @@
 import { StorageMemoIp2cCountryGuesser } from '@/entry.esm';
+import fakeIp2cFetch from './utils/fakeIp2cFetch';
 import makeFakeStorage from './utils/makeFakeStorage';
 
 describe('storageMemoIp2cCountryGuesser.js', () => {
@@ -22,9 +23,7 @@ describe('storageMemoIp2cCountryGuesser.js', () => {
   });
 
   it('should memoize promise from ip2c country guesser when not undefined', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('0'),
-    }));
+    fakeIp2cFetch(Promise.resolve('0'));
 
     const storageMemoIp2cCountryGuesser = new StorageMemoIp2cCountryGuesser({
       storage, key: 'dummyKey',
@@ -42,9 +41,7 @@ describe('storageMemoIp2cCountryGuesser.js', () => {
     expect(storage.setItem.mock.calls.length).toBe(0);
     expect(global.fetch.mock.calls.length).toBe(2);
 
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
+    fakeIp2cFetch();
 
     expect(await storageMemoIp2cCountryGuesser.guess()).toBe('FR');
     expect(storage.getItem.mock.calls[0][0]).toBe('dummyKey');
@@ -62,9 +59,7 @@ describe('storageMemoIp2cCountryGuesser.js', () => {
   });
 
   it('should use preference when defined', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({
-      text: () => Promise.resolve('1;FR'),
-    }));
+    fakeIp2cFetch();
 
     const storageMemoIp2cCountryGuesser = new StorageMemoIp2cCountryGuesser({
       storage,

--- a/tests/unit/utils/fakeIp2cFetch.js
+++ b/tests/unit/utils/fakeIp2cFetch.js
@@ -1,0 +1,5 @@
+export default function fakeIp2cFetch(returnResult = Promise.resolve('1;FR')) {
+  global.fetch = jest.fn(() => Promise.resolve({
+    text: () => returnResult,
+  }));
+}

--- a/tests/unit/utils/makeFakeStorage.js
+++ b/tests/unit/utils/makeFakeStorage.js
@@ -1,0 +1,11 @@
+export default function makeFakeStorage() {
+  const storage = {};
+  const storageMock = {};
+
+  storageMock.getItem = jest.fn((k) => storage[k]);
+  storageMock.setItem = jest.fn((k, v) => {
+    storage[k] = v;
+  });
+
+  return storageMock;
+}


### PR DESCRIPTION
## Proposed Changes

  - New interface `PreferableCountryGuesser` which extends the `CountryGuesser` interface: it adds a `setPreference(country: CountryIso2): void` method to customize the preferred country (and so bypass the guess).
  - `MemoIp2cCountryGuesser` and `StorageMemoIp2cCountryGuesser` are implementing this new interface
  - Phone input will call `setPreference` when the country changes (only if the `countryGuesser` is a `PreferableCountryGuesser`)
