### PR TITLE
feat: add support for rounded as common attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,29 +86,45 @@ Component usage:
 
 ### Table of contents
 
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Migration](#migration)
-- [Usage](#usage)
-- [Nuxt setup](#nuxt-setup)
-- [Props](#props)
-- [Events](#events)
-- [Slots](#slots)
-- [Examples](#examples)
-    - [Country icon modes](#country-icon-modes)
-    - [Validation](#validation)
-    - [Enabling searching countries](#enabling-searching-countries)
-    - [Customizing display format](#customizing-display-format)
-    - [Localization](#localization)
-- [Dependencies](#dependencies)
-- [Types](#types)
-    - [Country](#country)
-    - [Country guesser](#country-guesser)
-    - [Phone number formats](#phone-number-formats)
-    - [Phone number](#phone-number)
-    - [Message options](#message-options)
-    - [Message](#message)
-    - [Message resolver](#message-resolver)
+- [VPhoneInput](#vphoneinput)
+  - [Demo](#demo)
+  - [TL;DR](#tldr)
+  - [Documentation](#documentation)
+    - [Table of contents](#table-of-contents)
+    - [Requirements](#requirements)
+    - [Installation](#installation)
+    - [Usage](#usage)
+    - [Migration](#migration)
+    - [Nuxt setup](#nuxt-setup)
+    - [Props](#props)
+      - [Props inheritance](#props-inheritance)
+    - [Events](#events)
+    - [Slots](#slots)
+    - [Examples](#examples)
+      - [Country icon modes](#country-icon-modes)
+        - [SVG](#svg)
+        - [Sprite](#sprite)
+        - [Custom component](#custom-component)
+        - [Custom slot](#custom-slot)
+        - [No icon](#no-icon)
+      - [Validation](#validation)
+        - [Disabling default validation](#disabling-default-validation)
+      - [Enabling searching countries](#enabling-searching-countries)
+        - [When using plugin registration](#when-using-plugin-registration)
+        - [When using per-file registration](#when-using-per-file-registration)
+      - [Customizing display format](#customizing-display-format)
+      - [Localization](#localization)
+    - [Dependencies](#dependencies)
+    - [Types](#types)
+      - [Country](#country)
+      - [Country Guesser](#country-guesser)
+      - [Phone Number Formats](#phone-number-formats)
+      - [Message options](#message-options)
+      - [Message](#message)
+      - [Message resolver](#message-resolver)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
+  - [License](#license)
 
 ### Requirements
 
@@ -279,7 +295,7 @@ but be aware that:
 
 - Some props will only apply to the inputs wrapper `div` element: `id`, `class` and `style`.
 - Some props are applied to both inputs: `variant`, `flat`, `tile`, `density`, `singleLine`,
-  `hideDetails`, `direction`, `reverse`, `color`, `bgColor`, `theme`, `disabled` and `readonly`.
+  `hideDetails`, `direction`, `reverse`, `color`, `bgColor`, `theme`, `disabled`,`readonly`, and `rounded`.
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -86,45 +86,29 @@ Component usage:
 
 ### Table of contents
 
-- [VPhoneInput](#vphoneinput)
-  - [Demo](#demo)
-  - [TL;DR](#tldr)
-  - [Documentation](#documentation)
-    - [Table of contents](#table-of-contents)
-    - [Requirements](#requirements)
-    - [Installation](#installation)
-    - [Usage](#usage)
-    - [Migration](#migration)
-    - [Nuxt setup](#nuxt-setup)
-    - [Props](#props)
-      - [Props inheritance](#props-inheritance)
-    - [Events](#events)
-    - [Slots](#slots)
-    - [Examples](#examples)
-      - [Country icon modes](#country-icon-modes)
-        - [SVG](#svg)
-        - [Sprite](#sprite)
-        - [Custom component](#custom-component)
-        - [Custom slot](#custom-slot)
-        - [No icon](#no-icon)
-      - [Validation](#validation)
-        - [Disabling default validation](#disabling-default-validation)
-      - [Enabling searching countries](#enabling-searching-countries)
-        - [When using plugin registration](#when-using-plugin-registration)
-        - [When using per-file registration](#when-using-per-file-registration)
-      - [Customizing display format](#customizing-display-format)
-      - [Localization](#localization)
-    - [Dependencies](#dependencies)
-    - [Types](#types)
-      - [Country](#country)
-      - [Country Guesser](#country-guesser)
-      - [Phone Number Formats](#phone-number-formats)
-      - [Message options](#message-options)
-      - [Message](#message)
-      - [Message resolver](#message-resolver)
-  - [Contributing](#contributing)
-  - [Credits](#credits)
-  - [License](#license)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Migration](#migration)
+- [Usage](#usage)
+- [Nuxt setup](#nuxt-setup)
+- [Props](#props)
+- [Events](#events)
+- [Slots](#slots)
+- [Examples](#examples)
+    - [Country icon modes](#country-icon-modes)
+    - [Validation](#validation)
+    - [Enabling searching countries](#enabling-searching-countries)
+    - [Customizing display format](#customizing-display-format)
+    - [Localization](#localization)
+- [Dependencies](#dependencies)
+- [Types](#types)
+    - [Country](#country)
+    - [Country guesser](#country-guesser)
+    - [Phone number formats](#phone-number-formats)
+    - [Phone number](#phone-number)
+    - [Message options](#message-options)
+    - [Message](#message)
+    - [Message resolver](#message-resolver)
 
 ### Requirements
 
@@ -295,7 +279,7 @@ but be aware that:
 
 - Some props will only apply to the inputs wrapper `div` element: `id`, `class` and `style`.
 - Some props are applied to both inputs: `variant`, `flat`, `tile`, `density`, `singleLine`,
-  `hideDetails`, `direction`, `reverse`, `color`, `bgColor`, `theme`, `disabled`,`readonly`, and `rounded`.
+  `hideDetails`, `direction`, `reverse`, `color`, `bgColor`, `theme`, `disabled`, `readonly`, and `rounded`.
 
 ### Events
 

--- a/dev/components/PropsCard.vue
+++ b/dev/components/PropsCard.vue
@@ -73,6 +73,7 @@ export default defineComponent({
       disabled: createSwitch(),
       loading: createSwitch(),
       shaped: createSwitch(),
+      rounded: createSwitch(toItems(['sm', 'md', 'lg', 'xl', 'pill'])),
     });
     const themeItems = [{ value: 'light', title: 'Light' }, { value: 'dark', title: 'Dark' }];
 

--- a/src/components/VPhoneInput.vue
+++ b/src/components/VPhoneInput.vue
@@ -59,6 +59,7 @@ const INPUTS_COMMON_ATTRS = [
   'theme',
   'disabled',
   'readonly',
+  'rounded',
 ];
 
 export default defineComponent({


### PR DESCRIPTION
Related to #37 

## Proposed Changes

  - Adds support for `rounded` as a common attribute

Current behavior:

```js
<v-phone-input
    label="Preferred Phone (optional)"
    rounded="xl"
/>
```

<img width="665" alt="Screenshot 2024-10-17 at 8 17 41 AM" src="https://github.com/user-attachments/assets/1a62e09c-3759-4497-8aa9-b67fc44e120f">

Desired behavior:

<img width="648" alt="Screenshot 2024-10-17 at 8 18 00 AM" src="https://github.com/user-attachments/assets/3ca5cd55-369e-44aa-b90c-87a5de55c92a">

